### PR TITLE
remember last state instead of returning unknown;

### DIFF
--- a/commandlineplugin.py
+++ b/commandlineplugin.py
@@ -75,6 +75,7 @@ class CommandLinePlugin(FauxmoPlugin):
         self.on_cmd = on_cmd
         self.off_cmd = off_cmd
         self.state_cmd = state_cmd
+        self.last_state = "unknown"
 
         super().__init__(name=name, port=port)
 
@@ -97,6 +98,7 @@ class CommandLinePlugin(FauxmoPlugin):
             True if command seems to have run without error.
 
         """
+        self.last_state = "on"
         return self.run_cmd(self.on_cmd)
 
     def off(self) -> bool:
@@ -106,6 +108,7 @@ class CommandLinePlugin(FauxmoPlugin):
             True if command seems to have run without error.
 
         """
+        self.last_state = "off"
         return self.run_cmd(self.off_cmd)
 
     def get_state(self) -> str:
@@ -119,11 +122,12 @@ class CommandLinePlugin(FauxmoPlugin):
         should always return "off".
 
         Returns:
-            "on" or "off" if `state_cmd` is defined, "unknown" if undefined
+            "on" or "off" if `state_cmd` is defined,
+            otherwise state of last on/off call.
 
         """
         if self.state_cmd is None:
-            return "unknown"
+            return self.last_state
 
         returned_zero = self.run_cmd(self.state_cmd)
         if returned_zero is True:

--- a/mqttplugin.py
+++ b/mqttplugin.py
@@ -168,6 +168,8 @@ class MQTTPlugin(FauxmoPlugin):
             True if device seems to have been turned on.
 
         """
+        if not self.state_cmd:
+            self.status = "on"
         return self._publish(self.on_cmd, self.on_value)
 
     def off(self) -> bool:
@@ -177,6 +179,8 @@ class MQTTPlugin(FauxmoPlugin):
             True if device seems to have been turned off.
 
         """
+        if not self.state_cmd:
+            self.status = "off"
         return self._publish(self.off_cmd, self.off_value)
 
     def get_state(self) -> str:
@@ -186,10 +190,8 @@ class MQTTPlugin(FauxmoPlugin):
         immediately reflect state changed.
 
         Returns:
-            State if known, else "unknown".
+            Actual state if state_cmd is present,
+            otherwise state of last on/off call.
 
         """
-        if self.state_cmd is None:
-            return "unknown"
-
         return self.status

--- a/restapiplugin.py
+++ b/restapiplugin.py
@@ -149,6 +149,8 @@ class RESTAPIPlugin(FauxmoPlugin):
         self.state_response_on = state_response_on
         self.state_response_off = state_response_off
 
+        self.last_state = "unknown"
+
         if auth_type:
             if auth_type.lower() == "basic":
                 self.auth = HTTPBasicAuth(user, password)
@@ -160,10 +162,12 @@ class RESTAPIPlugin(FauxmoPlugin):
 
     def on(self) -> bool:
         """Turn device on."""
+        self.last_state = "on"
         return self.set_state(self.on_cmd, self.on_data, self.on_json)
 
     def off(self) -> bool:
         """Turn device off."""
+        self.last_state = "off"
         return self.set_state(self.off_cmd, self.off_data, self.off_json)
 
     def set_state(self, cmd: str, data: dict, json: dict) -> bool:
@@ -182,11 +186,11 @@ class RESTAPIPlugin(FauxmoPlugin):
         """Get device state.
 
         Returns:
-            "on", "off", or "unknown"
+            "on", "off", otherwise state of last on/off call.
 
         """
         if self.state_cmd is None:
-            return "unknown"
+            return self.last_state
 
         resp = requests.request(
             self.state_method,

--- a/tests/test_commandlineplugin.py
+++ b/tests/test_commandlineplugin.py
@@ -57,7 +57,7 @@ def test_commandlineplugin_unit() -> None:
 
         state = device.get_state()
         if device.state_cmd is None:
-            assert state == "unknown"
+            assert state == "off"
         else:
             if "on state" in device.name:
                 assert state == "on"

--- a/tests/test_restapiplugin.py
+++ b/tests/test_restapiplugin.py
@@ -81,4 +81,4 @@ def test_restapiplugin_unit(restapiplugin_target: pytest.fixture) -> None:
         if device.state_cmd is not None:
             assert state == "on"
         else:
-            assert state == "unknown"
+            assert state == "off"


### PR DESCRIPTION
fixes the issue described at https://github.com/n8henrie/fauxmo/issues/80 for commandlineplugin