### PR TITLE
MQTT plugin: optionally set client id

### DIFF
--- a/mqttplugin.py
+++ b/mqttplugin.py
@@ -29,6 +29,7 @@ Example config:
                     "state_cmd": "Home/Light/Study01",
                     "name":"MQTT Study Light 1",
                     "mqtt_server": "test.mosquitto.org",
+                    "mqtt_client_id": "study_light_one",
                     "mqtt_port": 1883
                 },
                 {
@@ -87,6 +88,7 @@ class MQTTPlugin(FauxmoPlugin):
         mqtt_pw: str = None,
         mqtt_user: str = None,
         mqtt_server: str = "127.0.0.1",
+        mqtt_client_id: str = "",
         state_cmd: str = None,
     ) -> None:
         """Initialize an MQTTPlugin instance.
@@ -97,6 +99,7 @@ class MQTTPlugin(FauxmoPlugin):
 
             mqttport: MQTT server port
             mqttserver: MQTT server address
+            mqttclientid: MQTT client id
             mqttuser: MQTT username
             mqttpw: MQTT password
             off_cmd: [ MQTT Queue, value to be publshed as str ] to turn off
@@ -109,7 +112,7 @@ class MQTTPlugin(FauxmoPlugin):
         self.status = "unknown"
         self._subscribed = False
 
-        self.client = Client()
+        self.client = Client(client_id=mqtt_client_id)
         if mqtt_user or mqtt_pw:
             self.client.username_pw_set(mqtt_user, mqtt_pw)
         self.client.on_connect = self.on_connect

--- a/tests/test_mqttplugin.py
+++ b/tests/test_mqttplugin.py
@@ -96,3 +96,20 @@ def test_mqtt_noauth(mock_client: MagicMock) -> None:
     )
     MQTTPlugin(**device_conf)
     mock_instance.username_pw_set.assert_not_called()
+
+
+@patch("mqttplugin.Client", autospec=True)
+def test_mqtt_clientid(mock_client: MagicMock) -> None:
+    """Ensure mqtt client id is properly set when configured."""
+    with open(config_path_str) as f:
+        config: dict = json.load(f)
+
+    device_conf = next(
+        device
+        for device in config["PLUGINS"]["MQTTPlugin"]["DEVICES"]
+        if device["mqtt_client_id"]
+    )
+    MQTTPlugin(**device_conf)
+    mock_client.assert_called_once_with(
+        client_id=device_conf["mqtt_client_id"]
+    )

--- a/tests/test_mqttplugin_config.json
+++ b/tests/test_mqttplugin_config.json
@@ -13,6 +13,7 @@
                     "state_cmd": "Home/Light/Study01",
                     "name":"MQTT Study Light 1",
                     "mqtt_server": "test.mosquitto.org",
+                    "mqtt_client_id": "test_client_1",
                     "mqtt_port": 1883
                 },
                 {


### PR DESCRIPTION
Set client id when provided in MQTT plugin's json config.